### PR TITLE
Actually use the port in the URI

### DIFF
--- a/src/processing/mqtt/MQTTClient.java
+++ b/src/processing/mqtt/MQTTClient.java
@@ -101,7 +101,11 @@ public class MQTTClient implements MqttCallback {
 				options.setPassword(pass.toCharArray());
 			}
 
-			client = new MqttClient("tcp://" + uri.getHost(), theID);
+			if (uri.getPort()!=-1){ 
+				client = new MqttClient("tcp://" + uri.getHost() + ":" + uri.getPort(), theID);
+			} else {
+				client = new MqttClient("tcp://" + uri.getHost(), theID);
+			}
 			client.setCallback(this);
 			client.connect(options);
 


### PR DESCRIPTION
I've noticed that the port number in the URI from the processing.mqtt.MQTTClient constructor wasn't used when rebuilding the URI for the org.eclipse.paho.client.mqttv3.MqttClient. This should fix that.

BTW: an updated jar is available: org.eclipse.paho.client.mqttv3-1.0.1.jar 
