### PR TITLE
Avoid a nullpointer exception when no credentials are given

### DIFF
--- a/src/processing/mqtt/MQTTClient.java
+++ b/src/processing/mqtt/MQTTClient.java
@@ -109,15 +109,16 @@ public class MQTTClient implements MqttCallback {
 
      try {
       MqttConnectOptions options = new MqttConnectOptions();
-
-      String[] auth = uri.getUserInfo().split(":");
-      if(auth.length > 0) {
-        String user = auth[0];
-        String pass = auth[1];
-        options.setUserName(user);
-        options.setPassword(pass.toCharArray());
+      if (uri.getUserInfo()!=null) {
+        String[] auth = uri.getUserInfo().split(":");
+        if(auth.length > 0) {
+          String user = auth[0];
+          String pass = auth[1];
+          options.setUserName(user);
+          options.setPassword(pass.toCharArray());
+        }
       }
-
+      
       if (uri.getPort()!=-1){
         client = new MqttClient("tcp://" + uri.getHost() + ":" + uri.getPort(), theID, new MemoryPersistence());
       } else {


### PR DESCRIPTION
I had some problems with NullPointer exceptions running the processing example with just an IP address (no credentials).

Turns out that getUserInfo() was returning null.

I don't know know if it's a bad idea to run without login and pwd, but my mosquitto server does not complain :)
