### PR TITLE
Updated versionnumber to org.eclipse.paho.client.mqttv3-1.2.0.jar for…

### DIFF
--- a/resources/build.xml
+++ b/resources/build.xml
@@ -150,7 +150,7 @@
     <target name="generate.javadoc" if="is.normal">
         <!-- create the java reference of the Library -->
         <javadoc bottom="Processing Library ${project.name} by ${author.name}. ${library.copyright}"
-                 classpath="${classpath.local.location}/core.jar;lib/org.eclipse.paho.client.mqttv3-1.0.1.jar"
+                 classpath="${classpath.local.location}/core.jar;lib/org.eclipse.paho.client.mqttv3-1.2.0.jar"
                  destdir="${project.tmp}/${project.name}/reference"
                  verbose="false"
                  stylesheetfile="resources/stylesheet.css"


### PR DESCRIPTION
The latest version of processing-mqtt did not work. the method "clientConnected"  was not called.

 I tried to build a version myself and found that an old version of org.eclipse.paho.client.mqttv was configured in build.xml, causing the build process to fail.

My guess is that this caused the build of the latest release to fail.

I think you should pull my changes, rebuild and publish a new release. It did work for me.